### PR TITLE
Fixed mandatory add/get

### DIFF
--- a/class/dnsCommon.ps1
+++ b/class/dnsCommon.ps1
@@ -75,6 +75,9 @@
 
 #>
 
+using namespace System.Collections
+using namespace System.Collections.ArrayList
+using namespace System.Collections.Generic
 
 enum DnsStatus {
     Success
@@ -744,6 +747,27 @@ class DnsCommon {
             $script:MainStream.Add($txt)
         }
     }
+
+    [bool]
+  hidden
+  IsSupportedArrayType($test) {
+    $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - Begin")
+    $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - Type:`n$($test | Out-String)")
+    if ( $test -is [array] `
+            -or $test -is [arrayList] `
+            -or $test.GetType().Name -is 'List`1' 
+            #-or $test -is [hashtable]
+        ) {
+        $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - Is supported array.")
+        $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - End")
+        return $true
+    } else {
+        $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - Is not a supported array.")
+        $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - End")
+        return $false
+    }
+    $script:Common.AddLog("[DnsCommon].IsSupportedArrayType(1) - End")
+  }
     #endregion UTILITY
 
     ## OUTPUT ##


### PR DESCRIPTION
Fixed an issue where the Mandatory SvcParamKey was not being added or retrieved correctly.

Migrated Mandatory to its own class instance, [DnsSvcParamKey0_Mandatory].

Updated [DnsSvcbHttpsSvcParam] to use the new [DnsSvcParamKey0_Mandatory] class.

Moved some mandatory validation to Add-DnsServerCustomResourceRecordHttps.

Updated $TTL to $TimeToLive to mirror DnsServer module parameter naming.

Copied IsSupportedArrayType() to [DnsCommon].

Updated DnsSvcbHttpsSvcParamKeysJSON.
  - Included unsupported SvcParamKeys and set them to Enabled = false.
  - Added HexStream, Class, and Enabled.
  - HexStream is the char representation of the SvcParamKey hex stream (e.g. alpn has a key hex stream of 0001).
  - Class is the name of the SvcParamKey class (e.g. DnsSvcParamKey0_Mandatory).
  - Enabled determines whether the SvcParamKey is a supported type.

Updated [DnsSvcbHttpsSvcParam] methods to use [DnsSvcParamKey0_Mandatory] methods and removed duplicate logic.